### PR TITLE
Add automatic dependency install

### DIFF
--- a/build/build_linux.sh
+++ b/build/build_linux.sh
@@ -3,6 +3,25 @@
 
 set -e
 
+# Function to check and install a package
+install_if_not_present() {
+    PACKAGE=$1
+    dpkg-query -W -f='${Status}' $PACKAGE 2>/dev/null | grep -q "ok installed"
+    if [ $? -ne 0 ]; then
+        echo "$PACKAGE is not installed. Installing..."
+        sudo apt-get update
+        sudo apt-get install -y $PACKAGE
+    else
+        echo "$PACKAGE is already installed."
+    fi
+}
+
+# Check and install libbsd-dev
+install_if_not_present libbsd-dev
+
+# Check and install freeglut3-dev
+install_if_not_present freeglut3-dev
+
 BUILDDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # ------------------------------------------------------------


### PR DESCRIPTION
Checks if `libbsd-dev` and `freeglut3-dev` are already installed, if not it installs them.

Fixes #9, users can build everything only by running `linux_build.sh`.